### PR TITLE
imgMouseUp sometimes doesn't work

### DIFF
--- a/jquery/cropbox.js
+++ b/jquery/cropbox.js
@@ -108,7 +108,7 @@
             },
             imgMouseUp = function(e)
             {
-                e.stopImmediatePropagation();
+                e.stopPropagation();
                 obj.state.dragable = false;
             },
             zoomImage = function(e)


### PR DESCRIPTION
`imgMouseUp `sometimes doesn't work(`obj.state.dragable = false;`execute, but image is still dragable) when user use it quickly, but when i use `e.stopPropagation();` the problem won't appear!