### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A lightweight and simple JavaScript, Jquery, YUI plugin to crop your avatar.
 - support dataUrl for displaying image (function getDataURL)
 - support Blob for uploading image (function getBlob)
 
-##Screenshot
+## Screenshot
 ![ScreenShot](/screenshot.jpg)
 
 # Usage


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
